### PR TITLE
Add linked frameworks in package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,18 @@ let package = Package(
         .target(
             name: "Branch",
             path: "Branch-SDK",
-            publicHeadersPath: "."
+            publicHeadersPath: ".",
+            linkerSettings: [
+                .linkedFramework("CoreServices"),
+                .linkedFramework("SystemConfiguration"),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
+                .linkedFramework("WebKit", .when(platforms: [.iOS])),
+                .linkedFramework("CoreSpotlight", .when(platforms: [.iOS])),
+                // Optional frameworks
+                .linkedFramework("AdServices", .when(platforms: [.iOS])),
+                .linkedFramework("iAd", .when(platforms: [.iOS])),
+                .linkedFramework("AdSupport")
+            ]
         ),
     ]
 )


### PR DESCRIPTION
The [guide](https://help.branch.io/developers-hub/docs/ios-basic-integration#via-swift-package-manager) for using with SPM mentions adding linked frameworks manually by user, this PR aims to improve that experience by specifying frameworks to be linked in swift package manifest instead providing a smooth experience similar to the cocoapods version.