### PR TITLE
INFRA-XX Auto-update GHA actions

### DIFF
--- a/.github/actions/import-release/action.yml
+++ b/.github/actions/import-release/action.yml
@@ -58,4 +58,4 @@ runs:
         git commit -a -m'[release] ${{ inputs.tag }}'
         git push
 
-        echo "::set-output name=sha::$(git rev-parse HEAD)"
+        echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -15,9 +15,9 @@ jobs:
       MAIN_REPO_REPO: ios-branch-deep-linking-attribution
     steps:
       - name: Check out SPM repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check out main iOS repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.MAIN_REPO_OWNER }}/${{ env.MAIN_REPO_REPO }}
           ref: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Auto-generated GHA actions upgrade io-branch-sdk-spm. Need to upgrade actions, because of Node v.12 is deprecated (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and set-output and save-state commands are deprecated (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)