### PR TITLE
sync with 3.3.0

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCRequestFactoryTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCRequestFactoryTests.m
@@ -25,7 +25,7 @@
 
 - (void)testInitWithBranchKeyNil {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:nil];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     // key is omitted when nil
@@ -34,7 +34,7 @@
 
 - (void)testInitWithBranchKeyEmpty {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@""];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     // empty string is allowed
@@ -43,14 +43,14 @@
 
 - (void)testInitWithBranchKey {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
 }
 
 - (void)testDataForInstall {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
@@ -64,7 +64,7 @@
 
 - (void)testDataForOpen {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForOpen];
+    NSDictionary *json = [factory dataForOpenWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
@@ -182,13 +182,13 @@
 
 - (void)testDataForShortURL {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForShortURLWithLinkDataDictionary:@{}.mutableCopy isSpotlightRequest:NO];
     XCTAssertNotNil(json);
 }
 
 - (void)testDataForLATD {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForLATDWithDataDictionary:@{}.mutableCopy];
     XCTAssertNotNil(json);
 }
 

--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "3.2.0"
+  s.version          = "3.3.0"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1974,7 +1974,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2009,7 +2009,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2215,7 +2215,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2254,7 +2254,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2291,7 +2291,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2326,7 +2326,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 Branch iOS SDK Change Log
 
+v.3.3.0
+- SDK behavior change to fix a race condition when opening a closed app with a link. In some apps, this race condition could cause the occasional loss of link data.
+ 
+When opening a closed app with a link, the Branch SDK will no longer attempt to merge the app open and link arrival lifecycle events. Apps will now get called on "app open" and on "link arrival", which are often very close together. If your app ignores callbacks with no link data, then this change should be transparent.
+
 v.3.2.0
 - Add support for setting DMA compliance parameters.
 - Update logging to allow a custom callback so clients may reroute Branch Logs to their logging infrastructure.

--- a/Sources/BranchSDK/BNCConfig.m
+++ b/Sources/BranchSDK/BNCConfig.m
@@ -8,7 +8,7 @@
 
 #include "BNCConfig.h"
 
-NSString * const BNC_SDK_VERSION  = @"3.2.0";
+NSString * const BNC_SDK_VERSION  = @"3.3.0";
 NSString * const BNC_LINK_URL = @"https://bnc.lt";
 NSString * const BNC_CDN_URL = @"https://cdn.branch.io";
 

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -76,7 +76,7 @@
     return Branch.trackingDisabled;
 }
 
-- (NSDictionary *)dataForInstall {
+- (NSDictionary *)dataForInstallWithURLString:(NSString *)urlString {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -100,6 +100,10 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    if (urlString) {
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+    }
+    
     [self addAppleAttributionTokenToJSON:json];
 
     // Install Only
@@ -116,7 +120,7 @@
     return json;
 }
 
-- (NSDictionary *)dataForOpen {
+- (NSDictionary *)dataForOpenWithURLString:(NSString *)urlString {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -142,6 +146,10 @@
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
+    
+    if (urlString) {
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+    }
     
     // Usually sent with install, but retry on open if it didn't get sent
     [self addAppleAttributionTokenToJSON:json];
@@ -279,7 +287,6 @@
 
     [self safeSetValue:self.preferenceHelper.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
     [self safeSetValue:self.preferenceHelper.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
-    [self safeSetValue:self.preferenceHelper.universalLinkUrl forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
     [self safeSetValue:self.preferenceHelper.initialReferrer forKey:BRANCH_REQUEST_KEY_INITIAL_REFERRER onDict:json];
     
     // This was only on opens before, cause it can't exist on install.

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -161,56 +161,17 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
     }
 }
 
-- (BOOL)removeInstallOrOpen {
+- (BranchOpenRequest *)findExistingInstallOrOpen {
     @synchronized (self) {
         for (NSUInteger i = 0; i < self.queue.count; i++) {
             BNCServerRequest *request = [self.queue objectAtIndex:i];
-            // Install extends open, so only need to check open.
+
+            // Install subclasses open, so only need to check open
             if ([request isKindOfClass:[BranchOpenRequest class]]) {
-                [[BranchLogger shared] logDebug:@"Removing open request."];
-                ((BranchOpenRequest *)request).callback = nil;
-                [self remove:request];
-                return YES;
+                return (BranchOpenRequest *)request;
             }
         }
-        return NO;
-    }
-}
-
-- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount {
-    @synchronized (self) {
-
-        BOOL requestAlreadyInProgress = networkCount > 0;
-
-        BNCServerRequest *openOrInstallRequest;
-        for (NSUInteger i = 0; i < self.queue.count; i++) {
-            BNCServerRequest *req = [self.queue objectAtIndex:i];
-            if ([req isKindOfClass:[BranchOpenRequest class]]) {
-                
-                // Already in front, nothing to do
-                if (i == 0 || (i == 1 && requestAlreadyInProgress)) {
-                    return (BranchOpenRequest *)req;
-                }
-
-                // Otherwise, pull this request out and stop early
-                openOrInstallRequest = [self removeAt:i];
-                break;
-            }
-        }
-        
-        if (!openOrInstallRequest) {
-            [[BranchLogger shared] logError:@"No install or open request in queue while trying to move it to the front." error:nil];
-            return nil;
-        }
-        
-        if (!requestAlreadyInProgress || !self.queue.count) {
-            [self insert:openOrInstallRequest at:0];
-        }
-        else {
-            [self insert:openOrInstallRequest at:1];
-        }
-        
-        return (BranchOpenRequest *)openOrInstallRequest;
+        return nil;
     }
 }
 

--- a/Sources/BranchSDK/BranchInstallRequest.m
+++ b/Sources/BranchSDK/BranchInstallRequest.m
@@ -20,7 +20,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key];
-    NSDictionary *params = [factory dataForInstall];
+    NSDictionary *params = [factory dataForInstallWithURLString:self.urlString];
 
     [serverInterface postRequest:params url:[[BNCServerAPI sharedInstance] installServiceURL] key:key callback:callback];
 }

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -47,7 +47,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key];
-    NSDictionary *params = [factory dataForOpen];
+    NSDictionary *params = [factory dataForOpenWithURLString:self.urlString];
 
     [serverInterface postRequest:params
         url:[[BNCServerAPI sharedInstance] openServiceURL]
@@ -140,13 +140,9 @@
     }
 
     NSString *referringURL = nil;
-    if (preferenceHelper.universalLinkUrl.length) {
-        referringURL = preferenceHelper.universalLinkUrl;
-    }
-    else if (preferenceHelper.externalIntentURI.length) {
-        referringURL = preferenceHelper.externalIntentURI;
-    }
-    else {
+    if (self.urlString.length > 0) {
+        referringURL = self.urlString;
+    } else {
         NSDictionary *sessionDataDict = [BNCEncodingUtils decodeJsonStringToDictionary:sessionData];
         NSString *link = sessionDataDict[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK];
         if ([link isKindOfClass:[NSString class]]) {

--- a/Sources/BranchSDK/Private/BNCRequestFactory.h
+++ b/Sources/BranchSDK/Private/BNCRequestFactory.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBranchKey:(NSString *)key NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (NSDictionary *)dataForInstall;
-- (NSDictionary *)dataForOpen;
+- (NSDictionary *)dataForInstallWithURLString:(nullable NSString *)urlString;
+- (NSDictionary *)dataForOpenWithURLString:(nullable NSString *)urlString;
 
 // Event data is passed in
 - (NSDictionary *)dataForEventWithEventDictionary:(NSMutableDictionary *)dictionary;

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -11,6 +11,9 @@
 
 @interface BranchOpenRequest : BNCServerRequest
 
+// URL that triggered this install or open event
+@property (nonatomic, copy, readwrite) NSString *urlString;
+
 @property (nonatomic, copy) callbackWithStatus callback;
 
 + (void) waitForOpenResponseLock;

--- a/Sources/BranchSDK/Public/BNCServerRequestQueue.h
+++ b/Sources/BranchSDK/Public/BNCServerRequestQueue.h
@@ -22,8 +22,8 @@
 - (NSInteger)queueDepth;
 
 - (BOOL)containsInstallOrOpen;
-- (BOOL)removeInstallOrOpen;
-- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount;
+
+- (BranchOpenRequest *)findExistingInstallOrOpen;
 
 - (void)persistEventually;
 - (void)persistImmediately;

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -740,28 +740,6 @@ Sets a custom base URL for all calls to the Branch API.
 - (void)disableAdNetworkCallouts:(BOOL)disableCallouts;
 
 /**
- Specify that Branch should NOT use an invisible SFSafariViewController to attempt cookie-based matching upon install.
- If you call this method, we will fall back to using our pool of cookie-IDFA pairs for matching.
- */
-- (void)disableCookieBasedMatching __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));
-
-/**
- TL;DR: If you're using a version of the Facebook SDK that prevents application:didFinishLaunchingWithOptions: from
- returning YES/true when a Universal Link is clicked, you should enable this option.
-
- Long explanation: in application:didFinishLaunchingWithOptions: you should choose one of the following:
-
- 1. Always `return YES;`, and do *not* invoke `[[Branch getInstance] accountForFacebookSDKPreventingAppLaunch];`
- 2. Allow the Facebook SDK to determine whether `application:didFinishLaunchingWithOptions:` returns `YES` or `NO`,
-    and invoke `[[Branch getInstance] accountForFacebookSDKPreventingAppLaunch];`
-
- The reason for this second option is that the Facebook SDK will return `NO` if a Universal Link opens the app
- but that UL is not a Facebook UL. Some developers prefer not to modify
- `application:didFinishLaunchingWithOptions:` to always return `YES` and should use this method instead.
- */
-- (void)accountForFacebookSDKPreventingAppLaunch __attribute__((deprecated(("Please ensure application:didFinishLaunchingWithOptions: always returns YES/true instead of using this method. It will be removed in a future release."))));
-
-/**
  For use by other Branch SDKs
  
  @param name Plugin name.  For example, Unity or React Native
@@ -785,16 +763,6 @@ Sets a custom base URL for all calls to the Branch API.
  @param value Object to be included in request metadata
  */
 - (void)setRequestMetadataKey:(NSString *)key value:(nullable id)value;
-
-- (void)enableDelayedInit __attribute__((deprecated(("No longer valid with new init process"))));
-
-- (void)disableDelayedInit __attribute__((deprecated(("No longer valid with new init process"))));
-
-- (nullable NSURL *)getUrlForOnboardingWithRedirectUrl:(nullable NSString *)redirectUrl __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));;
-
-- (void)resumeInit __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));
-
-- (void)setInstallRequestDelay:(NSInteger)installRequestDelay __attribute__((deprecated(("No longer valid with new init process"))));
 
 /**
  Disables the Branch SDK from tracking the user. This is useful for GDPR privacy compliance.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ Options:
 USAGE
 }
 
-version=3.2.0
+version=3.3.0
 prev_version="$version"
 
 if (( $# == 0 )); then


### PR DESCRIPTION
## Reference
SDK-2246

## Summary
Sync with 3.3.0 release

## Motivation
Release 3.3.0

SDK behavior change to fix a race condition when opening a closed app with a link. In some apps, this may improve link reliability.

When opening a closed app with a link, the Branch SDK will no longer attempt to merge the app open and link arrival lifecycle events. Apps will now get called on "app open" and on "link arrival", which are often very close together. If your app ignores callbacks with no link data, then this change should be transparent. If your app takes action on every branch callback, you may need to account for this change in behavior.

## Type Of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing Instructions

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
