### PR TITLE
Suppress storekit violations in Xcode 26

### DIFF
--- a/Sources/BranchSDK/Public/BranchEvent.h
+++ b/Sources/BranchSDK/Public/BranchEvent.h
@@ -60,6 +60,9 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 
 #pragma mark - BranchEvent
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @interface BranchEvent : NSObject <SKProductsRequestDelegate>
 
 - (instancetype _Nonnull) initWithName:(NSString*_Nonnull)name NS_DESIGNATED_INITIALIZER;
@@ -117,6 +120,8 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 - (void) logEventWithTransaction:(SKPaymentTransaction*_Nonnull)transaction;
 
 @end
+
+#pragma clang diagnostic pop
 
 #pragma mark - BranchEventRequest
 


### PR DESCRIPTION
## Reference
SDK-XXXX -- <TITLE>.

## Summary
Suppressed StoreKit Violations in the Xcode 26 beta. 

I do not know if this is the correct way to fix this , i.e. if the storekit 1 apis are generally still in use. However, it does remove the warnings. 

## Motivation

When compiling in Xcode 26, with warnings-as-errors, you will be unable to compile, even if your app has a target SDK lower than iOS 26. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
